### PR TITLE
Install node only appears once on the logs

### DIFF
--- a/azure-pipelines-install-node.yml
+++ b/azure-pipelines-install-node.yml
@@ -85,7 +85,7 @@ steps:
       Write-Output ("##vso[task.setvariable variable=NPM_CONFIG_PREFIX;]$installPath")
       
     displayName: "[Windows] Install Node $(NODE_VERSION)"
-- ${{ if or(ne(parameters.OS, 'windows'),ne(parameters.OS, 'unix'))  }}:
+- ${{ if and(ne(parameters.OS, 'windows'),ne(parameters.OS, 'unix'))  }}:
   - script: |
       echo ##vso[task.logissue type=error;]Invalid OS. Allowed values unix or windows.
       exit 1

--- a/azure-pipelines-install-node.yml
+++ b/azure-pipelines-install-node.yml
@@ -1,5 +1,6 @@
 # Template file to install node using NVM on linux and manual install on windows
 steps:
+- ${{ if eq(parameters.OS, 'unix')  }}:
   - script: |
       curl -sL https://raw.githubusercontent.com/creationix/nvm/v0.33.8/install.sh -o install.sh
       bash install.sh
@@ -15,8 +16,7 @@ steps:
       # make the new set path to be available in subsequent steps
       echo "##vso[task.setvariable variable=PATH;]$PATH"
     displayName: " [Unix] Install Node $(NODE_VERSION)"
-    condition: eq(variables['AGENT.OS'], 'Linux')
-
+- ${{ if eq(parameters.OS, 'windows')  }}:
   - powershell: |
       $nodeVersion = "$(NODE_VERSION)"
       if($nodeVersion.ToLower().EndsWith(".x")) {
@@ -85,4 +85,8 @@ steps:
       Write-Output ("##vso[task.setvariable variable=NPM_CONFIG_PREFIX;]$installPath")
       
     displayName: "[Windows] Install Node $(NODE_VERSION)"
-    condition: eq(variables['AGENT.OS'], 'Windows_NT')
+- ${{ if or(ne(parameters.OS, 'windows'),ne(parameters.OS, 'unix'))  }}:
+  - script: |
+      echo ##vso[task.logissue type=error;]Invalid OS. Allowed values unix or windows.
+      exit 1
+    displayName: Invalid operating system

--- a/azure-pipelines-install-node.yml
+++ b/azure-pipelines-install-node.yml
@@ -15,7 +15,7 @@ steps:
 
       # make the new set path to be available in subsequent steps
       echo "##vso[task.setvariable variable=PATH;]$PATH"
-    displayName: " [Unix] Install Node $(NODE_VERSION)"
+    displayName: "Install Node $(NODE_VERSION)"
 - ${{ if eq(parameters.OS, 'windows')  }}:
   - powershell: |
       $nodeVersion = "$(NODE_VERSION)"
@@ -84,7 +84,7 @@ steps:
       Write-Output ("##vso[task.setvariable variable=NPM_CONFIG_CACHE;]$installPath")
       Write-Output ("##vso[task.setvariable variable=NPM_CONFIG_PREFIX;]$installPath")
       
-    displayName: "[Windows] Install Node $(NODE_VERSION)"
+    displayName: "Install Node $(NODE_VERSION)"
 - ${{ if and(ne(parameters.OS, 'windows'),ne(parameters.OS, 'unix'))  }}:
   - script: |
       echo ##vso[task.logissue type=error;]Invalid OS. Allowed values unix or windows.

--- a/azure-pipelines-steps.yml
+++ b/azure-pipelines-steps.yml
@@ -8,6 +8,8 @@ steps:
 - template: azure-pipelines-install-node.yml
   parameters:
     NODE_VERSION : $(NODE_VERSION)
+    OS: ${{ parameters.OS }}
+
 
 #Start The Before Install Tasks 
 - script: |
@@ -54,6 +56,7 @@ steps:
 - template: azure-pipelines-install-node.yml
   parameters:
     NODE_VERSION : 9.x
+    OS: ${{ parameters.OS }}
 
 - script: |
     npm install --save-dev coveralls@2.10.0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,6 +34,7 @@ jobs:
   - template: "azure-pipelines-steps.yml"
     parameters:
       NODE_VERSION: $(NODE_VERSION)
+      OS: unix
 
 - job: Windows 
   strategy:
@@ -70,3 +71,4 @@ jobs:
   - template: "azure-pipelines-steps.yml"
     parameters:
       NODE_VERSION: $(NODE_VERSION)
+      OS: windows


### PR DESCRIPTION
The step only runs on the right os, so we don't have always have to steps (one executed other skipped) one for each OS.

the logs are now cleaner (at the expense of a parameter)